### PR TITLE
Patch recurring with props ids

### DIFF
--- a/lib/recurly-data.js
+++ b/lib/recurly-data.js
@@ -232,7 +232,7 @@ class RecurlyData {
         this._resources[prop] = value.href
 
         const hrefAsArr = value.href.split('/')
-        this[`${prop}_recurly_id`] = hrefAsArr[hrefAsArr.length - 1]
+        this[`recurly_${prop}_id`] = hrefAsArr[hrefAsArr.length - 1]
       }
       else {
         this[prop] = value

--- a/lib/recurly-data.js
+++ b/lib/recurly-data.js
@@ -230,6 +230,9 @@ class RecurlyData {
           this._resources = { }
         }
         this._resources[prop] = value.href
+
+        const hrefAsArr = value.href.split('/')
+        this[`${prop}_id`] = hrefAsArr[hrefAsArr.length - 1]
       }
       else {
         this[prop] = value

--- a/lib/recurly-data.js
+++ b/lib/recurly-data.js
@@ -232,7 +232,7 @@ class RecurlyData {
         this._resources[prop] = value.href
 
         const hrefAsArr = value.href.split('/')
-        this[`${prop}_id`] = hrefAsArr[hrefAsArr.length - 1]
+        this[`${prop}_recurly_id`] = hrefAsArr[hrefAsArr.length - 1]
       }
       else {
         this[prop] = value

--- a/test/test-02-api.js
+++ b/test/test-02-api.js
@@ -659,7 +659,6 @@ describe('Invoices', () => {
       const invoiceIds = Object.keys(invoices)
       invoiceIds.length.must.be.above(0)
       invoiceIds[0].must.not.equal('undefined')
-      console.log('TEST: ', invoices[invoiceIds[0]])
       invoices[invoiceIds[0]].recurly_account_id.must.not.equal('undefined')
       done()
     })

--- a/test/test-02-api.js
+++ b/test/test-02-api.js
@@ -659,6 +659,8 @@ describe('Invoices', () => {
       const invoiceIds = Object.keys(invoices)
       invoiceIds.length.must.be.above(0)
       invoiceIds[0].must.not.equal('undefined')
+      console.log('TEST: ', invoices[invoiceIds[0]])
+      invoices[invoiceIds[0]].recurly_account_id.must.not.equal('undefined')
       done()
     })
   })


### PR DESCRIPTION
This will add missing ids in recurly respones (e.g. `recurly_subscription_id`). They are prefixed with recurly to avoid conflicts with existing fields.