### PR TITLE
Don't throw `Error: unexpected status: 422` when account.create is called and account already exists

### DIFF
--- a/lib/models/account.js
+++ b/lib/models/account.js
@@ -104,9 +104,9 @@ class Account extends RecurlyData {
       }
 
       if (response.statusCode === 422) {
-        // An account with this ID exists already but in closed state. Reopen it.
+        // An account with this ID exists already
         if (_.get(payload, 'error.symbol') === 'taken' && _.get(payload, 'error.field') === 'account.account_code') {
-          return account.reopen(callback)
+          return callback(new Error('Account already exists'))
         }
         // Otherwise, rethrow the original error.
         else {

--- a/test/test-02-api.js
+++ b/test/test-02-api.js
@@ -173,17 +173,6 @@ describe('Account', () => {
     })
   })
 
-  it('can create or reopen a previously-closed account, transparently', done => {
-    const data = { id: testAccount.id }
-    recurly.Account().create(data, (err, newAccount) => {
-      demand(err).not.exist()
-      newAccount.must.be.an.object()
-      newAccount.first_name.must.equal('John') // from old data
-      newAccount.last_name.must.equal('Whorfin') // from old data
-      done()
-    })
-  })
-
   it('can fetch a single account', done => {
     const account = recurly.Account()
     account.id = testAccount.id

--- a/test/test-09-duplicate-account-creation.js
+++ b/test/test-09-duplicate-account-creation.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const demand = require('must')
+const Recurring = require('../lib/recurly')
+const recurly = new Recurring()
+
+const nock = require('nock')
+
+describe('Account creation in case of duplicate account', function() {
+  it('should call custom logger', function(done) {
+    const account = recurly.Account()
+    const accountData = { id: 'test' }
+
+    const xmlResponse = `
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+    <error field="account.account_code" symbol="taken">has already been taken</error>
+</errors>`.trim()
+
+    nock('https://api.recurly.com/v2')
+      .post(`/accounts`)
+      .reply(422, xmlResponse)
+
+    account.create(accountData, err => {
+      demand(err).to.exist()
+      err.message.must.eql('Account already exists')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
When account already exists, don't try to reopen account, return proper error to caller.

`An account with this ID exists already but in closed state. Reopen it.` was not always true, in our case account exists, it's open so there is no need in reopening it (which currently ends with cryptic error message Error: unexpected status: 422).

If you want to handle reopen case, handle it in your business logic.