### PR TITLE
Add due_on property to invoices

### DIFF
--- a/lib/models/invoice.js
+++ b/lib/models/invoice.js
@@ -25,6 +25,7 @@ class Invoice extends RecurlyData {
         'currency',
         'customer_notes',
         'collection_method',
+        'due_on',
         'invoice_number',
         'invoice_number_prefix',
         'line_items',

--- a/lib/recurly-data.js
+++ b/lib/recurly-data.js
@@ -88,6 +88,10 @@ class RecurlyData {
 
     options.method = method
 
+    if (uri.startsWith('https://api.recurly.com/v2/invoices')) {
+      options.headers['X-Api-Version'] = '2.10'
+    }
+
     this.execute(options, callback)
   }
 


### PR DESCRIPTION
It is necessary to force the API to v2.10 since the `due_on` property is not available on older versions.