### PR TITLE
Add log to markFailed invoice requests

### DIFF
--- a/lib/models/invoice.js
+++ b/lib/models/invoice.js
@@ -170,10 +170,21 @@ class Invoice extends RecurlyData {
     }
 
     uri = uri || `${Invoice.ENDPOINT}/${this.invoice_number}/mark_failed`
+    const debugData = {
+      url: uri
+    }
+
+    log.info(`[Invoice/markFailed] Start`, { debugData })
 
     this.put(uri, null, (err, response, payload) => {
       const error = handleRecurlyError(err, response, payload, [ 200 ])
       if (error) {
+        log.error(`[Invoice/markFailed] Error`, {
+          err,
+          error,
+          debugData,
+          payload
+        })
         return callback(error)
       }
       this.inflate(payload)


### PR DESCRIPTION
Trying to understand why these requests are failing on staging and not locally (even when using staging API key..), I am adding logs (we have the same for markSuccessful)